### PR TITLE
Fix CompareTray hydration mismatch by deferring localStorage read to useEffect

### DIFF
--- a/src/components/compare/compare-context.tsx
+++ b/src/components/compare/compare-context.tsx
@@ -38,12 +38,20 @@ function readInitialComparePrograms(): CompareProgram[] {
 }
 
 export function CompareProvider({ children }: { children: ReactNode }) {
-  const [programs, setPrograms] = useState<CompareProgram[]>(readInitialComparePrograms);
+  const [programs, setPrograms] = useState<CompareProgram[]>([]);
+  const [hydrated, setHydrated] = useState(false);
 
+  // Hydrate from localStorage after mount to avoid SSR mismatch
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    setPrograms(readInitialComparePrograms());
+    setHydrated(true);
+  }, []);
+
+  // Persist to localStorage only after initial hydration
+  useEffect(() => {
+    if (!hydrated) return;
     localStorage.setItem(STORAGE_KEY, JSON.stringify(programs));
-  }, [programs]);
+  }, [programs, hydrated]);
 
   const add = useCallback((program: CompareProgram) => {
     setPrograms((prev) => {


### PR DESCRIPTION
Initialize compare programs state as empty during SSR, then hydrate from
localStorage in a useEffect after mount. This prevents the server/client
divergence that caused React hydration warnings.

Fixes #2

https://claude.ai/code/session_015SCHsCEVRnebrYeybcrK6L