### PR TITLE
fix: show basic listing state for sparse program cards (closes #8)

### DIFF
--- a/src/app/(app)/search/program-card.tsx
+++ b/src/app/(app)/search/program-card.tsx
@@ -132,6 +132,9 @@ export const ProgramCard = React.forwardRef<HTMLDivElement, ProgramCardProps>(
         {program.distanceKm != null && (
           <span>{program.distanceKm.toFixed(1)} km</span>
         )}
+        {!program.ageRange && !program.costRange && !program.hours && (
+          <span className="italic text-neutral-400">Limited info available</span>
+        )}
       </div>
 
       {program.lastVerifiedAt && (


### PR DESCRIPTION
Closes #8

Programs with no age range, cost, or hours data (typically family childcare homes with only CCL licensing data) now display "Limited info available" instead of an empty detail row.

**Audit findings:**
- Search card has no `website` field — no broken link icons possible
- Profile page website links are already properly guarded with conditional rendering
- Search API does not filter by website — programs without websites already appear in results
- The actual issue was an empty detail row when all detail fields are null

**Change:** Added fallback text in `program-card.tsx` when ageRange, costRange, and hours are all missing.

Verified: build, typecheck, tests (9/9), lint pass (pre-existing issues only).