### PR TITLE
fix: improve Lighthouse accessibility scores on /intake and /search (closes #4)

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -19,9 +19,9 @@ export default function AppLayout({
             Skip to main content
           </a>
           <NavHeader />
-          <div id="main-content" className="mx-auto flex min-h-0 w-full max-w-7xl flex-1 px-4 sm:px-6 lg:px-8 py-8 pb-24">
+          <main id="main-content" className="mx-auto flex min-h-0 w-full max-w-7xl flex-1 px-4 sm:px-6 lg:px-8 py-8 pb-24">
             {children}
-          </div>
+          </main>
           <CompareTray />
         </div>
       </CompareProvider>

--- a/src/app/(app)/search/filter-sidebar.tsx
+++ b/src/app/(app)/search/filter-sidebar.tsx
@@ -142,7 +142,7 @@ export function FilterSidebar({
           Max Monthly Budget
         </label>
         <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral-400">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500">
             $
           </span>
           <input
@@ -324,7 +324,7 @@ export function FilterSidebar({
         </Button>
       )}
 
-      <p className="text-xs text-neutral-400">
+      <p className="text-xs text-neutral-500">
         {resultCount} program{resultCount !== 1 ? "s" : ""} found
       </p>
     </aside>

--- a/src/app/(app)/search/program-card.tsx
+++ b/src/app/(app)/search/program-card.tsx
@@ -78,7 +78,7 @@ export const ProgramCard = React.forwardRef<HTMLDivElement, ProgramCardProps>(
     >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
-          <h3 className="font-serif truncate text-sm font-semibold text-neutral-900">
+          <h2 className="font-serif truncate text-sm font-semibold text-neutral-900">
             <Link
               href={`/programs/${program.slug}`}
               className="hover:text-brand-600 hover:underline"
@@ -86,7 +86,7 @@ export const ProgramCard = React.forwardRef<HTMLDivElement, ProgramCardProps>(
             >
               {program.name}
             </Link>
-          </h3>
+          </h2>
           {program.address && (
             <p className="mt-0.5 truncate text-xs text-neutral-500">
               {program.address}
@@ -102,7 +102,7 @@ export const ProgramCard = React.forwardRef<HTMLDivElement, ProgramCardProps>(
           <button
             onClick={handleCompareToggle}
             disabled={!inCompare && isFull}
-            className={`rounded px-2 py-1 text-xs transition-colors ${
+            className={`rounded px-3 py-1.5 text-xs transition-colors ${
               inCompare
                 ? "bg-brand-100 text-brand-700 hover:bg-brand-200"
                 : "text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700 disabled:opacity-40"
@@ -135,7 +135,7 @@ export const ProgramCard = React.forwardRef<HTMLDivElement, ProgramCardProps>(
       </div>
 
       {program.lastVerifiedAt && (
-        <p className="mt-2 text-xs text-neutral-400">
+        <p className="mt-2 text-xs text-neutral-500">
           Verified{" "}
           {new Date(program.lastVerifiedAt).toLocaleDateString("en-US", {
             month: "short",

--- a/src/app/(onboarding)/intake/step-child.tsx
+++ b/src/app/(onboarding)/intake/step-child.tsx
@@ -47,10 +47,11 @@ export function StepChild({ data, onUpdate, onNext }: StepChildProps) {
 
       {/* Date of birth */}
       <fieldset className="space-y-3">
-        <label className="block text-sm font-medium text-neutral-700">
+        <label htmlFor="childDob" className="block text-sm font-medium text-neutral-700">
           Child&apos;s date of birth
         </label>
         <input
+          id="childDob"
           type="date"
           value={data.childDob ?? ""}
           onChange={(e) =>
@@ -61,13 +62,14 @@ export function StepChild({ data, onUpdate, onNext }: StepChildProps) {
           }
           className="block w-full rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-neutral-700 focus:ring-1 focus:ring-neutral-700 focus:outline-none"
         />
-        <p className="text-xs text-neutral-400">
+        <p className="text-xs text-neutral-500">
           Or, if expecting:
         </p>
-        <label className="block text-sm font-medium text-neutral-700">
+        <label htmlFor="childExpectedDueDate" className="block text-sm font-medium text-neutral-700">
           Expected due date
         </label>
         <input
+          id="childExpectedDueDate"
           type="date"
           value={data.childExpectedDueDate ?? ""}
           onChange={(e) =>
@@ -132,10 +134,11 @@ export function StepChild({ data, onUpdate, onNext }: StepChildProps) {
 
       {/* Number of children */}
       <div className="space-y-2">
-        <label className="block text-sm font-medium text-neutral-700">
+        <label htmlFor="numChildren" className="block text-sm font-medium text-neutral-700">
           Number of children enrolling
         </label>
         <select
+          id="numChildren"
           value={data.numChildren}
           onChange={(e) => {
             const num = parseInt(e.target.value, 10);

--- a/src/app/(onboarding)/intake/step-schedule.tsx
+++ b/src/app/(onboarding)/intake/step-schedule.tsx
@@ -59,7 +59,7 @@ export function StepSchedule({
           Monthly budget (max)
         </label>
         <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral-400">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral-500">
             $
           </span>
           <input


### PR DESCRIPTION
Closes #4

## Summary
- Ran Lighthouse audit on all 6 accessible routes
- Fixed accessibility issues that brought `/intake` (85→100) and `/search` (87→95) below 90
- All routes now score ≥90 on Lighthouse Accessibility

## Changes
- **`<main>` landmark** in app layout (was `<div>`) — fixes `landmark-one-main`
- **Form label associations** (`htmlFor`/`id`) on date inputs and select in intake wizard — fixes `label`, `select-name`
- **Color contrast** — upgraded `text-neutral-400` to `text-neutral-500` across 4 files — fixes `color-contrast`
- **Heading order** — program card heading `h3` → `h2` — fixes `heading-order`
- **Touch target size** — compare button padding increased — fixes `target-size`

## Lighthouse Scores (post-fix)
| Route | Perf | A11y | BP | SEO |
|-------|------|------|----|-----|
| `/` | 97 | 100 | 96 | 91 |
| `/schools/noe-valley-preschools` | 97 | 95 | 96 | 91 |
| `/intake` | 96 | **100** | 96 | 91 |
| `/search` | 94 | **95** | 96 | 91 |
| `/privacy` | 97 | 100 | 96 | 91 |
| `/terms` | 97 | 100 | 96 | 91 |

## Verification
- [x] `npm run build` passes
- [x] `npm run typecheck` clean
- [x] `npm test` — 9/9 passing
- [x] `npm run lint` — no new errors (2 pre-existing in map-panel.tsx)